### PR TITLE
Restructure and Rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ notifications:
 # uncomment the following lines to override the default test script
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("PDEOperators"); Pkg.test("PDEOperators"; coverage=true)'
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("DiffEqOperators"); Pkg.test("DiffEqOperators"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("PDEOperators")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'cd(Pkg.dir("DiffEqOperators")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("PDEOperators")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'cd(Pkg.dir("DiffEqOperators")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
-  - 0.5
   - 0.6
 allow_failures:
-    - julia: 0.6
     - julia: nightly
 notifications:
   email: false

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The PDEOperators.jl package is licensed under the MIT "Expat" License:
+The DiffEqOperators.jl package is licensed under the MIT "Expat" License:
 
 > Copyright (c) 2017: shivin9.
 > 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# PDEOperators
+# DiffEqOperators.jl
 
-[![Build Status](https://travis-ci.org/JuliaDiffEq/PDEOperators.jl.svg?branch=master)](https://travis-ci.org/JuliaDiffEq/PDEOperators.jl)
-[![Build status](https://ci.appveyor.com/api/projects/status/epkywa6xf09ma02j?svg=true)](https://ci.appveyor.com/project/ChrisRackauckas/pdeoperators-jl)
-[![Coverage Status](https://coveralls.io/repos/JuliaDiffEq/PDEOperators.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaDiffEq/PDEOperators.jl?branch=master)
-[![codecov.io](http://codecov.io/github/shivin9/PDEOperators.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaDiffEq/PDEOperators.jl?branch=master)
+[![Build Status](https://travis-ci.org/JuliaDiffEq/DiffEqOperators.jl.svg?branch=master)](https://travis-ci.org/JuliaDiffEq/DiffEqOperators.jl)
+[![Build status](https://ci.appveyor.com/api/projects/status/epkywa6xf09ma02j?svg=true)](https://ci.appveyor.com/project/ChrisRackauckas/DiffEqOperators-jl)
+[![Coverage Status](https://coveralls.io/repos/JuliaDiffEq/DiffEqOperators.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaDiffEq/DiffEqOperators.jl?branch=master)
+[![codecov.io](http://codecov.io/github/shivin9/DiffEqOperators.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaDiffEq/DiffEqOperators.jl?branch=master)
 
 ## Julia Library to solve PDEs using Finite Difference Method
 This library is going to be a part of DiffEq.jl to become the PDE solver alongside Fenics.jl.
 
-Blog posts related to the development of PDEOperators.jl can he found [here](https://shivin9.github.io/blog/blogposts/)
+Blog posts related to the development of DiffEqOperators.jl can he found [here](https://shivin9.github.io/blog/blogposts/)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DiffEqOperators.jl
 
 [![Build Status](https://travis-ci.org/JuliaDiffEq/DiffEqOperators.jl.svg?branch=master)](https://travis-ci.org/JuliaDiffEq/DiffEqOperators.jl)
-[![Build status](https://ci.appveyor.com/api/projects/status/epkywa6xf09ma02j?svg=true)](https://ci.appveyor.com/project/ChrisRackauckas/DiffEqOperators-jl)
+[![Build status](https://ci.appveyor.com/api/projects/status/au9knv63u9oh1aie?svg=true)](https://ci.appveyor.com/project/ChrisRackauckas/diffeqoperators-jl)
 [![Coverage Status](https://coveralls.io/repos/JuliaDiffEq/DiffEqOperators.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaDiffEq/DiffEqOperators.jl?branch=master)
 [![codecov.io](http://codecov.io/github/shivin9/DiffEqOperators.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaDiffEq/DiffEqOperators.jl?branch=master)
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
-DiffEqBase 1.11.0
+DiffEqBase 1.19.0
 LinearMaps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"PDEOperators\"); Pkg.build(\"PDEOperators\")"
+      Pkg.clone(pwd(), \"DiffEqOperators\"); Pkg.build(\"DiffEqOperators\")"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"PDEOperators\")"
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"DiffEqOperators\")"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,13 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
-
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+    - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+matrix:
+  allow_failures:
+    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 branches:
   only:
     - master
@@ -17,9 +20,10 @@ notifications:
     on_build_status_changed: false
 
 install:
+  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        $env:JULIA_URL,
         "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia

--- a/docs/HeatEquation.md
+++ b/docs/HeatEquation.md
@@ -1,4 +1,4 @@
-# Solving the Heat Equation using PDEOperators
+# Solving the Heat Equation using DiffEqOperators
 
 In this tutorial we will solve the famous heat equation using the explicit discretization on a 2D `space x time` grid. The heat equation is:-
         

--- a/docs/KdV.md
+++ b/docs/KdV.md
@@ -1,4 +1,4 @@
-# Solving the Heat Equation using PDEOperators
+# Solving the Heat Equation using DiffEqOperators
 
 In this tutorial we will try to solve the famous **KdV equation** which describes the motion of waves on shallow water surfaces.
 The equation is commonly written as 
@@ -7,7 +7,7 @@ The equation is commonly written as
 
 Lets consider the cosine wave as the initial waveform and evolve it using the equation with a [periodic boundary condition](https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.15.240). This example is taken from [here](https://en.wikipedia.org/wiki/Korteweg%E2%80%93de_Vries_equation).
 
-    using PDEOperators, DifferentialEquations, Plots
+    using DiffEqOperators, DifferentialEquations, Plots
     x = collect(0 : 1/99 : 2);
     u0 = cos.(π*x);
     du3 = zeros(u0); # a container array
@@ -17,7 +17,7 @@ Lets consider the cosine wave as the initial waveform and evolve it using the eq
         copy!(du, -u.*du .- 0.022^2.*du3)
     end
 
-Now defining our PDEOperators
+Now defining our DiffEqOperators
 ```
     A = LinearOperator{Float64}(1,2,1/99,199,:periodic,:periodic);
     C = LinearOperator{Float64}(3,2,1/99,199,:periodic,:periodic);

--- a/docs/PDEOperators.md
+++ b/docs/PDEOperators.md
@@ -1,4 +1,4 @@
-# Basics of PDEOperators
+# Basics of DiffEqOperators
 
 In this tutorial we will explore the basic functionalities of PDEOperator which is used to obtain the discretizations of PDEs of appropriate derivative and approximation order.
 
@@ -52,7 +52,7 @@ We can get the linear operator as a matrix as follows:-
 Note that we **don't** need to define the `BC` only for `:D0` and `:periodic` boundary conditions so you can ignore it.
 
 
-Now coming to the main functionality of PDEOperators ie. taking finite difference discretizations of functions.
+Now coming to the main functionality of DiffEqOperators ie. taking finite difference discretizations of functions.
 
     julia> x = collect(0 : 1/99 : 1);
     julia> u0 = x.^2 -x;

--- a/docs/Telegrapher Equations.ipynb
+++ b/docs/Telegrapher Equations.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "using DifferentialEquations, Plots\n",
     "using Revise\n",
-    "using PDEOperators\n",
+    "using DiffEqOperators\n",
     "pyplot()"
    ]
   },

--- a/src/DiffEqOperators.jl
+++ b/src/DiffEqOperators.jl
@@ -1,6 +1,6 @@
 __precompile__()
 
-module PDEOperators
+module DiffEqOperators
 
 import LinearMaps: LinearMap, AbstractLinearMap
 import Base: *, getindex

--- a/src/DiffEqOperators.jl
+++ b/src/DiffEqOperators.jl
@@ -7,7 +7,6 @@ import Base: *, getindex
 using DiffEqBase, StaticArrays
 
 abstract type AbstractDiffEqDerivativeOperator{T} <: AbstractDiffEqLinearOperator{T} end
-export PDEOperator
 
 ### Basic Operators
 include("diffeqscalar.jl")

--- a/src/DiffEqOperators.jl
+++ b/src/DiffEqOperators.jl
@@ -6,7 +6,7 @@ import LinearMaps: LinearMap, AbstractLinearMap
 import Base: *, getindex
 using DiffEqBase, StaticArrays
 
-abstract type AbstractDiffEqDerivativeOperator{T} <: AbstractDiffEqLinearOperator{T} end
+abstract type AbstractDerivativeOperator{T} <: AbstractDiffEqLinearOperator{T} end
 
 ### Basic Operators
 include("diffeqscalar.jl")
@@ -18,5 +18,5 @@ include("derivative_operators/fornberg.jl")
 include("derivative_operators/boundary_operators.jl")
 
 export DiffEqScalar, DiffEqArrayOperator
-export AbstractDiffEqDerivativeOperator, DerivativeOperator
+export AbstractDerivativeOperator, DerivativeOperator
 end # module

--- a/src/PDEOperators.jl
+++ b/src/PDEOperators.jl
@@ -6,12 +6,18 @@ import LinearMaps: LinearMap, AbstractLinearMap
 import Base: *, getindex
 using DiffEqBase, StaticArrays
 
-abstract type AbstractLinearOperator{T} <: AbstractDiffEqOperator{T} end
+abstract type AbstractDiffEqDerivativeOperator{T} <: AbstractDiffEqLinearOperator{T} end
 export PDEOperator
 
-include("linear_operator.jl")
-include("fornberg.jl")
-include("boundary_operators.jl")
+### Basic Operators
+include("diffeqscalar.jl")
+include("array_operator.jl")
 
-export AbstractLinearOperator, LinearOperator
+### Derivative Operators
+include("derivative_operators/derivative_operator.jl")
+include("derivative_operators/fornberg.jl")
+include("derivative_operators/boundary_operators.jl")
+
+export DiffEqScalar, DiffEqArrayOperator
+export AbstractDiffEqDerivativeOperator, DerivativeOperator
 end # module

--- a/src/array_operator.jl
+++ b/src/array_operator.jl
@@ -1,0 +1,105 @@
+### AbstractDiffEqLinearOperator defined by an array and update functions
+mutable struct DiffEqArrayOperator{T,Arr<:AbstractMatrix{T},Sca,F} <: AbstractDiffEqLinearOperator{T}
+    A::Arr
+    α::Sca
+    _isreal::Bool
+    _issymmetric::Bool
+    _ishermitian::Bool
+    _isposdef::Bool
+    update_func::F
+end
+DEFAULT_UPDATE_FUNC = (L,t,u)->nothing
+function DiffEqArrayOperator(A::AbstractMatrix{T},α=1.0,
+                             update_func = DEFAULT_UPDATE_FUNC) where T
+    if (typeof(α) <: Number)
+        _α = DiffEqScalar(nothing,α)
+    elseif (typeof(α) <: DiffEqScalar) # Assume it's some kind of function
+        _α = DiffEqScalar(α,1.0)
+    else # Must be a DiffEqScalar already
+        _α = α
+    end
+    DiffEqArrayOperator{T,typeof(A),typeof(_α),
+    typeof(update_func)}(
+    A,_α,isreal(A),issymmetric(A),ishermitian(A),
+    isposdef(A),update_func)
+end
+
+Base.isreal(L::DiffEqArrayOperator) = L._isreal
+Base.issymmetric(L::DiffEqArrayOperator) = L._issymmetric
+Base.ishermitian(L::DiffEqArrayOperator) = L._ishermitian
+Base.isposdef(L::DiffEqArrayOperator) = L._isposdef
+DiffEqBase.is_constant(L::DiffEqArrayOperator) = L.update_func == DEFAULT_UPDATE_FUNC
+
+DiffEqBase.update_coefficients!(L::DiffEqArrayOperator,t,u) = (L.update_func(L.A,t,u); L.α = L.α(t); nothing)
+DiffEqBase.update_coefficients(L::DiffEqArrayOperator,t,u)  = (L.update_func(L.A,t,u); L.α = L.α(t); L)
+
+function (L::DiffEqArrayOperator)(t,u)
+  update_coefficients!(L,t,u)
+  L*u
+end
+function (L::DiffEqArrayOperator)(t,u,du)
+  update_coefficients!(L,t,u)
+  A_mul_B!(du,L,u)
+end
+
+### Forward some extra operations
+function Base.:*(α::Number,L::DiffEqArrayOperator)
+    DiffEqArrayOperator(L.A,DiffEqScalar(L.func,L.coeff*α),L.update_func)
+end
+Base.:*(L::DiffEqArrayOperator,α::Number) = α*L
+Base.:*(L::DiffEqArrayOperator,b::AbstractVector) = L.α.coeff*L.A*b
+Base.:*(L::DiffEqArrayOperator,b::AbstractArray) = L.α.coeff*L.A*b
+function Base.A_mul_B!(v::AbstractVector,L::DiffEqArrayOperator,b::AbstractVector)
+    A_mul_B!(v,L.A,b)
+    scale!(b,L.α.coeff)
+end
+function Base.A_mul_B!(v::AbstractArray,L::DiffEqArrayOperator,b::AbstractArray)
+    A_mul_B!(v,L.A,b)
+    scale!(b,L.α.coeff)
+end
+Base.expm(L::DiffEqArrayOperator) = expm(L.α.coeff*L.A)
+Base.size(L::DiffEqArrayOperator) = size(L.A)
+
+function Base.A_ldiv_B!(x,L::DiffEqArrayOperator, b::AbstractArray)
+    A_ldiv_B!(x,L.A,b)
+    scale!(x,inv(L.α.coeff))
+end
+
+"""
+FactorizedDiffEqArrayOperator{T,I}
+
+A helper function for holding factorized version of the DiffEqArrayOperator
+"""
+struct FactorizedDiffEqArrayOperator{T,I}
+    A::T
+    inv_coeff::I
+end
+
+Base.factorize(L::DiffEqArrayOperator)         = FactorizedDiffEqArrayOperator(factorize(L.A),inv(L.α.coeff))
+Base.lufact(L::DiffEqArrayOperator,args...)    = FactorizedDiffEqArrayOperator(lufact(L.A,args...),inv(L.α.coeff))
+Base.lufact!(L::DiffEqArrayOperator,args...)   = FactorizedDiffEqArrayOperator(lufact!(L.A,args...),inv(L.α.coeff))
+Base.qrfact(L::DiffEqArrayOperator,args...)    = FactorizedDiffEqArrayOperator(qrfact(L.A,args...),inv(L.α.coeff))
+Base.qrfact!(L::DiffEqArrayOperator,args...)   = FactorizedDiffEqArrayOperator(qrfact!(L.A,args...),inv(L.α.coeff))
+Base.cholfact(L::DiffEqArrayOperator,args...)  = FactorizedDiffEqArrayOperator(cholfact(L.A,args...),inv(L.α.coeff))
+Base.cholfact!(L::DiffEqArrayOperator,args...) = FactorizedDiffEqArrayOperator(cholfact!(L.A,args...),inv(L.α.coeff))
+Base.ldltfact(L::DiffEqArrayOperator,args...)  = FactorizedDiffEqArrayOperator(ldltfact(L.A,args...),inv(L.α.coeff))
+Base.ldltfact!(L::DiffEqArrayOperator,args...) = FactorizedDiffEqArrayOperator(ldltfact!(L.A,args...),inv(L.α.coeff))
+Base.bkfact(L::DiffEqArrayOperator,args...)    = FactorizedDiffEqArrayOperator(bkfact(L.A,args...),inv(L.α.coeff))
+Base.bkfact!(L::DiffEqArrayOperator,args...)   = FactorizedDiffEqArrayOperator(bkfact!(L.A,args...),inv(L.α.coeff))
+Base.lqfact(L::DiffEqArrayOperator,args...)    = FactorizedDiffEqArrayOperator(lqfact(L.A,args...),inv(L.α.coeff))
+Base.lqfact!(L::DiffEqArrayOperator,args...)   = FactorizedDiffEqArrayOperator(lqfact!(L.A,args...),inv(L.α.coeff))
+Base.svdfact(L::DiffEqArrayOperator,args...)   = FactorizedDiffEqArrayOperator(svdfact(L.A,args...),inv(L.α.coeff))
+Base.svdfact!(L::DiffEqArrayOperator,args...)  = FactorizedDiffEqArrayOperator(svdfact!(L.A,args...),inv(L.α.coeff))
+
+function Base.A_ldiv_B!(x,L::FactorizedDiffEqArrayOperator, b::AbstractArray)
+    A_ldiv_B!(x,L.A,b)
+    scale!(x,inv(L.inv_coeff))
+end
+function Base.:\(L::FactorizedDiffEqArrayOperator, b::AbstractArray)
+    (L.A \ b) * L.inv_coeff
+end
+
+@inline Base.getindex(L::DiffEqArrayOperator,i::Int) = L.A[i]
+@inline Base.getindex{N}(L::DiffEqArrayOperator,I::Vararg{Int, N}) = L.A[I...]
+@inline Base.setindex!(L::DiffEqArrayOperator, v, i::Int) = (L.A[i]=v)
+@inline Base.setindex!{N}(L::DiffEqArrayOperator, v, I::Vararg{Int, N}) = (L.A[I...]=v)

--- a/src/derivative_operators/boundary_operators.jl
+++ b/src/derivative_operators/boundary_operators.jl
@@ -24,14 +24,14 @@ end
 
 
 #= LEFT BOUNDARY CONDITIONS =#
-function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,:Dirichlet0,RBC})
+function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,:Dirichlet0,RBC})
     for i in 1 : A.boundary_point_count
         dirichlet_0!(x_temp, x, A.stencil_coefs, i)
     end
 end
 
 
-function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,:Dirichlet,RBC})
+function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,:Dirichlet,RBC})
     x[1] = A.boundary_condition[][1][3]
     for i in 1 : A.boundary_point_count
         dirichlet_1!(x_temp, x, A.stencil_coefs, i)
@@ -39,21 +39,21 @@ function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x:
 end
 
 
-function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,:periodic,RBC})
+function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,:periodic,RBC})
     for i in 1 : A.boundary_point_count
         periodic!(x_temp, x, A.stencil_coefs, i)
     end
 end
 
 
-function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,:Neumann0,RBC})
+function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,:Neumann0,RBC})
     for i in 1 : A.boundary_point_count
         neumann0!(x_temp, x, A.stencil_coefs, i)
     end
 end
 
 
-function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,:Neumann,RBC})
+function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,:Neumann,RBC})
     @inbounds for i in 1 : A.boundary_point_count
         bc = A.low_boundary_coefs[][i]
         tmp = zero(T)
@@ -66,7 +66,7 @@ function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x:
 end
 
 
-function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,:Robin,RBC})
+function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,:Robin,RBC})
     @inbounds for i in 1 : A.boundary_point_count
         bc = A.low_boundary_coefs[][i]
         tmp = zero(T)
@@ -79,7 +79,7 @@ function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x:
 end
 
 
-function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,:None,RBC})
+function convolve_BC_left!{T<:Real,S<:SVector,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,:None,RBC})
     halfstencil = div(A.stencil_length, 2)
     for i in 1 : A.boundary_point_count
         @inbounds bc = A.low_boundary_coefs[][i]
@@ -94,7 +94,7 @@ end
 
 
 #= INTERIOR CONVOLUTION =#
-function convolve_interior!{T<:Real,S<:SVector,LBC,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,LBC,RBC})
+function convolve_interior!{T<:Real,S<:SVector,LBC,RBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,LBC,RBC})
     N = length(x)
     coeffs = A.stencil_coefs
     mid = div(A.stencil_length, 2) + 1
@@ -111,7 +111,7 @@ end
 
 
 #= RIGHT BOUNDARY CONDITIONS =#
-function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,LBC,:Dirichlet0})
+function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,LBC,:Dirichlet0})
     # Dirichlet 0 means that the value at the boundary is 0
     N = length(x)
     for i in 1 : A.boundary_point_count
@@ -120,7 +120,7 @@ function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x
 end
 
 
-function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,LBC,:Dirichlet})
+function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,LBC,:Dirichlet})
     N = length(x)
     x[end] = A.boundary_condition[][2][3]
     for i in 1 : A.boundary_point_count
@@ -129,7 +129,7 @@ function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x
 end
 
 
-function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,LBC,:periodic})
+function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,LBC,:periodic})
     N = length(x)
     for i in 1 : A.boundary_point_count
         periodic!(x_temp, x, A.stencil_coefs, N - A.boundary_point_count + i)
@@ -137,7 +137,7 @@ function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x
 end
 
 
-function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,LBC,:Neumann0})
+function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,LBC,:Neumann0})
     N = length(x)
     for i in 1 : A.boundary_point_count
         neumann0!(x_temp, x, A.stencil_coefs, N - A.boundary_point_count + i)
@@ -145,7 +145,7 @@ function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x
 end
 
 
-function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,LBC,:Neumann})
+function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,LBC,:Neumann})
     N = length(x)
     @inbounds for i in 1 : A.boundary_point_count
         bc = A.high_boundary_coefs[][A.boundary_point_count - i + 1]
@@ -160,7 +160,7 @@ function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x
 end
 
 
-function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,LBC,:Robin})
+function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,LBC,:Robin})
     N = length(x)
     @inbounds for i in 1 : A.boundary_point_count
         bc = A.high_boundary_coefs[][A.boundary_point_count - i + 1]
@@ -174,7 +174,7 @@ function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x
 end
 
 
-function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::LinearOperator{T,S,LBC,:None})
+function convolve_BC_right!{T<:Real,S<:SVector,LBC}(x_temp::AbstractVector{T}, x::AbstractVector{T}, A::DerivativeOperator{T,S,LBC,:None})
     halfstencil = div(A.stencil_length, 2)
     for i in 1 : A.boundary_point_count
         @inbounds bc = A.high_boundary_coefs[][i]

--- a/src/derivative_operators/derivative_operator.jl
+++ b/src/derivative_operators/derivative_operator.jl
@@ -1,39 +1,39 @@
 export update_coefficients!
 
-function *(A::AbstractLinearOperator,x::AbstractVector)
+function *(A::AbstractDerivativeOperator,x::AbstractVector)
     #=
         We will output a vector which is a supertype of the types of A and x
         to ensure numerical stability
     =#
     y = zeros(promote_type(eltype(A),eltype(x)), length(x))
-    Base.A_mul_B!(y, A::AbstractLinearOperator, x::AbstractVector)
+    Base.A_mul_B!(y, A::AbstractDerivativeOperator, x::AbstractVector)
     return y
 end
 
 
-function *(A::AbstractLinearOperator,M::AbstractMatrix)
+function *(A::AbstractDerivativeOperator,M::AbstractMatrix)
     #=
         We will output a vector which is a supertype of the types of A and x
         to ensure numerical stability
     =#
     y = zeros(promote_type(eltype(A),eltype(M)), size(M))
-    Base.A_mul_B!(y, A::AbstractLinearOperator, M::AbstractMatrix)
+    Base.A_mul_B!(y, A::AbstractDerivativeOperator, M::AbstractMatrix)
     return y
 end
 
 
-function *(M::AbstractMatrix,A::AbstractLinearOperator)
+function *(M::AbstractMatrix,A::AbstractDerivativeOperator)
     #=
         We will output a vector which is a supertype of the types of A and x
         to ensure numerical stability
     =#
     y = zeros(promote_type(eltype(A),eltype(M)), size(M))
-    Base.A_mul_B!(y, A::AbstractLinearOperator, M::AbstractMatrix)
+    Base.A_mul_B!(y, A::AbstractDerivativeOperator, M::AbstractMatrix)
     return y
 end
 
 
-function *(A::AbstractLinearOperator,B::AbstractLinearOperator)
+function *(A::AbstractDerivativeOperator,B::AbstractDerivativeOperator)
     # TODO: it will result in an operator which calculates
     #       the derivative of order A.dorder + B.dorder of
     #       approximation_order = min(approx_A, approx_B)
@@ -51,7 +51,7 @@ function negate!{T}(arr::T)
 end
 
 
-immutable LinearOperator{T<:Real,S<:SVector,LBC,RBC} <: AbstractLinearOperator{T}
+immutable DerivativeOperator{T<:Real,S<:SVector,LBC,RBC} <: AbstractDerivativeOperator{T}
     derivative_order    :: Int
     approximation_order :: Int
     dx                  :: T
@@ -64,7 +64,7 @@ immutable LinearOperator{T<:Real,S<:SVector,LBC,RBC} <: AbstractLinearOperator{T
     high_boundary_coefs :: Ref{Vector{Vector{T}}}
     boundary_condition  :: Ref{Tuple{Tuple{T,T,Any},Tuple{T,T,Any}}}
 
-    Base.@pure function LinearOperator{T,S,LBC,RBC}(derivative_order::Int, approximation_order::Int, dx::T,
+    Base.@pure function DerivativeOperator{T,S,LBC,RBC}(derivative_order::Int, approximation_order::Int, dx::T,
                                             dimension::Int, BC) where {T<:Real,S<:SVector,LBC,RBC}
         dimension            = dimension
         dx                   = dx
@@ -90,12 +90,12 @@ immutable LinearOperator{T<:Real,S<:SVector,LBC,RBC} <: AbstractLinearOperator{T
             boundary_condition
             )
     end
-    (::Type{LinearOperator{T}}){T<:Real}(dorder::Int,aorder::Int,dx::T,dim::Int,LBC::Symbol,RBC::Symbol;BC=((zero(T),zero(T),zero(T)),(zero(T),zero(T),zero(T)))) =
-        LinearOperator{T, SVector{dorder+aorder-1+(dorder+aorder)%2,T}, LBC, RBC}(dorder, aorder, dx, dim, BC)
+    (::Type{DerivativeOperator{T}}){T<:Real}(dorder::Int,aorder::Int,dx::T,dim::Int,LBC::Symbol,RBC::Symbol;BC=((zero(T),zero(T),zero(T)),(zero(T),zero(T),zero(T)))) =
+        DerivativeOperator{T, SVector{dorder+aorder-1+(dorder+aorder)%2,T}, LBC, RBC}(dorder, aorder, dx, dim, BC)
 end
 
 
-function update_coefficients!{T<:Real,S<:SVector,RBC,LBC}(A::LinearOperator{T,S,LBC,RBC};BC=nothing)
+function update_coefficients!{T<:Real,S<:SVector,RBC,LBC}(A::DerivativeOperator{T,S,LBC,RBC};BC=nothing)
     if BC != nothing
         LBC == :Robin ? (length(BC[1])==3 || error("Enter the new left boundary condition as a 1-tuple")) :
                         (length(BC[1])==1 || error("Robin BC needs a 3-tuple for left boundary condition"))
@@ -396,36 +396,36 @@ end
 #################################################################################################
 
 
-(L::LinearOperator)(t,u) = L*u
-(L::LinearOperator)(t,u,du) = A_mul_B!(du,L,u)
-get_LBC{A,B,C,D}(::LinearOperator{A,B,C,D}) = C
-get_RBC{A,B,C,D}(::LinearOperator{A,B,C,D}) = D
+(L::DerivativeOperator)(t,u) = L*u
+(L::DerivativeOperator)(t,u,du) = A_mul_B!(du,L,u)
+get_LBC{A,B,C,D}(::DerivativeOperator{A,B,C,D}) = C
+get_RBC{A,B,C,D}(::DerivativeOperator{A,B,C,D}) = D
 
 
 # ~ bound checking functions ~
-checkbounds(A::AbstractLinearOperator, k::Integer, j::Integer) =
+checkbounds(A::AbstractDerivativeOperator, k::Integer, j::Integer) =
     (0 < k ≤ size(A, 1) && 0 < j ≤ size(A, 2) || throw(BoundsError(A, (k,j))))
 
-checkbounds(A::AbstractLinearOperator, kr::Range, j::Integer) =
+checkbounds(A::AbstractDerivativeOperator, kr::Range, j::Integer) =
     (checkbounds(A, first(kr), j); checkbounds(A,  last(kr), j))
 
-checkbounds(A::AbstractLinearOperator, k::Integer, jr::Range) =
+checkbounds(A::AbstractDerivativeOperator, k::Integer, jr::Range) =
     (checkbounds(A, k, first(jr)); checkbounds(A, k,  last(jr)))
 
-checkbounds(A::AbstractLinearOperator, kr::Range, jr::Range) =
+checkbounds(A::AbstractDerivativeOperator, kr::Range, jr::Range) =
     (checkbounds(A, kr, first(jr)); checkbounds(A, kr,  last(jr)))
 
-checkbounds(A::AbstractLinearOperator, k::Colon, j::Integer) =
+checkbounds(A::AbstractDerivativeOperator, k::Colon, j::Integer) =
     (0 < j ≤ size(A, 2) || throw(BoundsError(A, (size(A,1),j))))
 
-checkbounds(A::AbstractLinearOperator, k::Integer, j::Colon) =
+checkbounds(A::AbstractDerivativeOperator, k::Integer, j::Colon) =
     (0 < k ≤ size(A, 1) || throw(BoundsError(A, (k,size(A,2)))))
 
 
-# BandedMatrix{A,B,C,D}(A::LinearOperator{A,B,C,D}) = BandedMatrix(full(A, A.stencil_length), A.stencil_length, div(A.stencil_length,2), div(A.stencil_length,2))
+# BandedMatrix{A,B,C,D}(A::DerivativeOperator{A,B,C,D}) = BandedMatrix(full(A, A.stencil_length), A.stencil_length, div(A.stencil_length,2), div(A.stencil_length,2))
 
 # ~~ getindex ~~
-@inline function getindex(A::LinearOperator, i::Int, j::Int)
+@inline function getindex(A::DerivativeOperator, i::Int, j::Int)
     @boundscheck checkbounds(A, i, j)
     mid = div(A.stencil_length, 2) + 1
     bpc = A.stencil_length - mid
@@ -440,9 +440,9 @@ checkbounds(A::AbstractLinearOperator, k::Integer, j::Colon) =
 end
 
 # scalar - colon - colon
-@inline getindex(A::LinearOperator, kr::Colon, jr::Colon) = full(A)
+@inline getindex(A::DerivativeOperator, kr::Colon, jr::Colon) = full(A)
 
-@inline function getindex(A::LinearOperator, rc::Colon, j)
+@inline function getindex(A::DerivativeOperator, rc::Colon, j)
     T = eltype(A.stencil_coefs)
     v = zeros(T, A.dimension)
     v[j] = one(T)
@@ -452,7 +452,7 @@ end
 
 
 # symmetric right now
-@inline function getindex(A::LinearOperator, i, cc::Colon)
+@inline function getindex(A::DerivativeOperator, i, cc::Colon)
     T = eltype(A.stencil_coefs)
     v = zeros(T, A.dimension)
     v[i] = one(T)
@@ -462,31 +462,31 @@ end
 
 
 # UnitRanges
-@inline function getindex(A::LinearOperator, rng::UnitRange{Int}, cc::Colon)
+@inline function getindex(A::DerivativeOperator, rng::UnitRange{Int}, cc::Colon)
     m = full(A)
     return m[rng, cc]
 end
 
 
-@inline function getindex(A::LinearOperator, rc::Colon, rng::UnitRange{Int})
+@inline function getindex(A::DerivativeOperator, rc::Colon, rng::UnitRange{Int})
     m = full(A)
     return m[rnd, cc]
 end
 
 
-@inline function getindex(A::LinearOperator, r::Int, rng::UnitRange{Int})
+@inline function getindex(A::DerivativeOperator, r::Int, rng::UnitRange{Int})
     m = A[r, :]
     return m[rng]
 end
 
 
-@inline function getindex(A::LinearOperator, rng::UnitRange{Int}, c::Int)
+@inline function getindex(A::DerivativeOperator, rng::UnitRange{Int}, c::Int)
     m = A[:, c]
     return m[rng]
 end
 
 
-@inline function getindex{T}(A::LinearOperator{T}, rng::UnitRange{Int}, cng::UnitRange{Int})
+@inline function getindex{T}(A::DerivativeOperator{T}, rng::UnitRange{Int}, cng::UnitRange{Int})
     N = A.dimension
     if (rng[end] - rng[1]) > ((cng[end] - cng[1]))
         mat = zeros(T, (N, length(cng)))
@@ -519,7 +519,7 @@ end
 end
 
 
-function Base.A_mul_B!{T<:Real}(x_temp::AbstractVector{T}, A::LinearOperator{T}, x::AbstractVector{T})
+function Base.A_mul_B!{T<:Real}(x_temp::AbstractVector{T}, A::DerivativeOperator{T}, x::AbstractVector{T})
     convolve_BC_left!(x_temp, x, A)
     convolve_interior!(x_temp, x, A)
     convolve_BC_right!(x_temp, x, A)
@@ -527,7 +527,7 @@ function Base.A_mul_B!{T<:Real}(x_temp::AbstractVector{T}, A::LinearOperator{T},
 end
 
 
-function Base.A_mul_B!{T<:Real}(x_temp::AbstractArray{T,2}, A::LinearOperator{T}, M::AbstractMatrix{T})
+function Base.A_mul_B!{T<:Real}(x_temp::AbstractArray{T,2}, A::DerivativeOperator{T}, M::AbstractMatrix{T})
     if size(x_temp) == reverse(size(M))
         for i = 1:size(M,1)
             A_mul_B!(view(x_temp,i,:), A, view(M,i,:))
@@ -540,21 +540,21 @@ function Base.A_mul_B!{T<:Real}(x_temp::AbstractArray{T,2}, A::LinearOperator{T}
 end
 
 
-# Base.length(A::LinearOperator) = A.stencil_length
-Base.ndims(A::LinearOperator) = 2
-Base.size(A::LinearOperator) = (A.dimension, A.dimension)
-Base.length(A::LinearOperator) = reduce(*, size(A))
+# Base.length(A::DerivativeOperator) = A.stencil_length
+Base.ndims(A::DerivativeOperator) = 2
+Base.size(A::DerivativeOperator) = (A.dimension, A.dimension)
+Base.length(A::DerivativeOperator) = reduce(*, size(A))
 
 
 #=
     Currently, for the evenly spaced grid we have a symmetric matrix
 =#
-Base.transpose(A::LinearOperator) = A
-Base.ctranspose(A::LinearOperator) = A
-Base.issymmetric(::AbstractLinearOperator) = true
+Base.transpose(A::DerivativeOperator) = A
+Base.ctranspose(A::DerivativeOperator) = A
+Base.issymmetric(::AbstractDerivativeOperator) = true
 
 
-function Base.full{T}(A::LinearOperator{T}, N::Int=A.dimension)
+function Base.full{T}(A::DerivativeOperator{T}, N::Int=A.dimension)
     @assert N >= A.stencil_length # stencil must be able to fit in the matrix
     mat = zeros(T, (N, N))
     v = zeros(T, N)
@@ -571,7 +571,7 @@ function Base.full{T}(A::LinearOperator{T}, N::Int=A.dimension)
 end
 
 
-function Base.sparse{T}(A::LinearOperator{T})
+function Base.sparse{T}(A::DerivativeOperator{T})
     N = A.dimension
     mat = spzeros(T, N, N)
     v = zeros(T, N)

--- a/src/derivative_operators/fornberg.jl
+++ b/src/derivative_operators/fornberg.jl
@@ -1,13 +1,13 @@
 #############################################################
 # Fornberg algorithm
-function derivative{T<:Real}(y::Vector{T}, A::LinearOperator{T})
+function derivative{T<:Real}(y::Vector{T}, A::DerivativeOperator{T})
     dy = zeros(T, length(y))
     derivative!(dy, y, A)
     return dy
 end
 
 
-function derivative!{T<:Real}(dy::Vector{T}, y::Vector{T}, A::LinearOperator{T})
+function derivative!{T<:Real}(dy::Vector{T}, y::Vector{T}, A::DerivativeOperator{T})
     N = length(y)
     #=
         Derivative is calculated in 3 parts:-
@@ -47,7 +47,7 @@ function derivative!{T<:Real}(dy::Vector{T}, y::Vector{T}, A::LinearOperator{T})
 end
 
 
-function construct_differentiation_matrix{T<:Real}(N::Int, A::LinearOperator{T})
+function construct_differentiation_matrix{T<:Real}(N::Int, A::DerivativeOperator{T})
     #=
         This is for calculating the derivative in one go. But we are creating a function
         which can calculate the derivative by-passing the costly matrix multiplication.
@@ -67,7 +67,7 @@ function construct_differentiation_matrix{T<:Real}(N::Int, A::LinearOperator{T})
 end
 
 
-# immutable FiniteDifference <: AbstractLinearOperator
+# immutable FiniteDifference <: AbstractDerivativeOperator
 #     # TODO: the general case ie. with an uneven grid
 # end
 

--- a/src/diffeqscalar.jl
+++ b/src/diffeqscalar.jl
@@ -1,0 +1,25 @@
+"""
+DiffEqScalar Interface
+
+DiffEqScalar(func,coeff=1.0)
+
+This is a function with a coefficient.
+
+α(t) returns a new DiffEqScalar with an updated coefficient.
+"""
+struct DiffEqScalar{F,T}
+    func::F
+    coeff::T
+    DiffEqScalar{T}(func) where T = new{typeof(func),T}(func,one(T))
+    DiffEqScalar{F,T}(func,coeff) where {F,T} = new{F,T}(func,coeff)
+end
+DiffEqScalar(func,coeff=1.0) = DiffEqScalar{typeof(func),typeof(coeff)}(func,coeff)
+function (α::DiffEqScalar)(t)
+    if α.func == nothing
+        return DiffEqScalar(α.func,α.coeff)
+    else
+        return DiffEqScalar(α.func,α.func(t))
+    end
+end
+Base.:*(α::Number,B::DiffEqScalar) = DiffEqScalar(B.func,B.coeff*α)
+Base.:*(B::DiffEqScalar,α::Number) = DiffEqScalar(B.func,B.coeff*α)

--- a/test/KdV.jl
+++ b/test/KdV.jl
@@ -13,8 +13,8 @@ context("KdV equation (Single Solition)")do
     oriu = zeros(x);
     du3 = zeros(x);
     temp = zeros(x);
-    A = LinearOperator{Float64}(1,4,Δx,length(x),:periodic,:periodic);
-    C = LinearOperator{Float64}(3,4,Δx,length(x),:periodic,:periodic);
+    A = DerivativeOperator{Float64}(1,4,Δx,length(x),:periodic,:periodic);
+    C = DerivativeOperator{Float64}(3,4,Δx,length(x),:periodic,:periodic);
 
     function KdV(t, u, du)
        C(t,u,du3)
@@ -49,8 +49,8 @@ context("KdV equation (Double Solition)")do
 
     du3 = zeros(x);
     temp = zeros(x);
-    A = LinearOperator{Float64}(1,2,1/99,length(x),:None,:None);
-    C = LinearOperator{Float64}(3,2,1/99,length(x),:None,:None);
+    A = DerivativeOperator{Float64}(1,2,1/99,length(x),:None,:None);
+    C = DerivativeOperator{Float64}(3,2,1/99,length(x),:None,:None);
 
     function KdV(t, u, du)
        C(t,u,du3)

--- a/test/dirichlet.jl
+++ b/test/dirichlet.jl
@@ -7,7 +7,7 @@ context("Dirichlet0 Boundary Conditions:")do
     d_order = 2
     approx_order = 2
     x = collect(1:h_inv:N).^2
-    A = LinearOperator{Float64}(2,2,1/99,length(x),:Dirichlet0,:Dirichlet0,BC=(0.0,0.0))
+    A = DerivativeOperator{Float64}(2,2,1/99,length(x),:Dirichlet0,:Dirichlet0,BC=(0.0,0.0))
     boundary_points = A.boundary_point_count
     res = A*x
     @test res[boundary_points + 1: N - boundary_points] ≈ 2.0*ones(N - 2*boundary_points);
@@ -16,12 +16,12 @@ context("Dirichlet0 Boundary Conditions:")do
     d_order = 4
     approx_order = 10
     y = collect(1:1.0:N).^4 - 2*collect(1:1.0:N).^3 + collect(1:1.0:N).^2;
-    A = LinearOperator{Float64}(d_order,approx_order,1.0,N,:Dirichlet0,:Dirichlet0,BC=(0.0,0.0))
+    A = DerivativeOperator{Float64}(d_order,approx_order,1.0,N,:Dirichlet0,:Dirichlet0,BC=(0.0,0.0))
     boundary_points = A.boundary_point_count
     res = A*y
     @test res[boundary_points + 1: N - boundary_points] ≈ 24.0*ones(N - 2*boundary_points) atol=10.0^-1; # Float64 is less stable
 
-    A = LinearOperator{BigFloat}(d_order,approx_order,one(BigFloat),N,:Dirichlet0,:Dirichlet0,BC=(0.0,0.0))
+    A = DerivativeOperator{BigFloat}(d_order,approx_order,one(BigFloat),N,:Dirichlet0,:Dirichlet0,BC=(0.0,0.0))
     y = convert(Array{BigFloat, 1}, y)
     res = A*y
     @test res[boundary_points + 1: N - boundary_points] ≈ 24.0*ones(N - 2*boundary_points) atol=10.0^-approx_order;

--- a/test/heat_eqn.jl
+++ b/test/heat_eqn.jl
@@ -5,7 +5,7 @@ using DifferentialEquations
 context("Parabolic Heat Equation with Dirichlet BCs:")do
     x = collect(-pi : 2pi/511 : pi);
     u0 = -(x - 0.5).^2 + 1/12;
-    A = LinearOperator{Float64}(2,2,2π/511,512,:Dirichlet,:Dirichlet;BC=(u0[1],u0[end]));
+    A = DerivativeOperator{Float64}(2,2,2π/511,512,:Dirichlet,:Dirichlet;BC=(u0[1],u0[end]));
     heat_eqn = ODEProblem(A, u0, (0.,10.));
     soln = solve(heat_eqn,dense=false,tstops=0:0.01:10);
 
@@ -20,10 +20,10 @@ context("Parabolic Heat Equation with Neumann BCs:")do
     dx = 2π/(N-1)
     x = collect(-pi : dx : pi);
     u0 = -(x - 0.5).^2 + 1/12;
-    B = LinearOperator{Float64}(1,2,dx,N,:None,:None);
+    B = DerivativeOperator{Float64}(1,2,dx,N,:None,:None);
     deriv_start, deriv_end = (B*u0)[1], (B*u0)[end]
 
-    A = LinearOperator{Float64}(2,2,dx,N,:Neumann,:Neumann;BC=(deriv_start,deriv_end));
+    A = DerivativeOperator{Float64}(2,2,dx,N,:Neumann,:Neumann;BC=(deriv_start,deriv_end));
 
     heat_eqn = ODEProblem(A, u0, (0.,10.));
     soln = solve(heat_eqn,dense=false,tstops=0:0.01:10);
@@ -42,14 +42,14 @@ context("Parabolic Heat Equation with Robin BCs:")do
     dx = 2π/(N-1)
     x = collect(-pi : dx : pi);
     u0 = -(x - 0.5).^2 + 1/12;
-    B = LinearOperator{Float64}(1,2,dx,N,:None,:None);
+    B = DerivativeOperator{Float64}(1,2,dx,N,:None,:None);
     deriv_start, deriv_end = (B*u0)[1], (B*u0)[end]
     params = 2*rand(2)-1
 
     left_RBC = params[1]*u0[1] - params[2]*deriv_start
     right_RBC = params[1]*u0[end] + params[2]*deriv_end
 
-    A = LinearOperator{Float64}(2,2,dx,N,:Robin,:Dirichlet;BC=((params[1],params[2],left_RBC),u0[end]));
+    A = DerivativeOperator{Float64}(2,2,dx,N,:Robin,:Dirichlet;BC=((params[1],params[2],left_RBC),u0[end]));
 
     heat_eqn = ODEProblem(A, u0, (0.,10.));
     soln = solve(heat_eqn,dense=false,tstops=0:0.01:10);

--- a/test/neumann.jl
+++ b/test/neumann.jl
@@ -6,11 +6,11 @@ context("Neumann0 Boundary:")do
     d_order = 2
     approx_order = 2
     x = collect(1:1.0:N).^2
-    A = LinearOperator{Float64}(2,2,1.0,N,:Neumann0,:Neumann0)
+    A = DerivativeOperator{Float64}(2,2,1.0,N,:Neumann0,:Neumann0)
     boundary_points = A.boundary_point_count
     res = A*x
     @test res[boundary_points + 1: N - boundary_points] ≈ 2.0*ones(N - 2*boundary_points) atol=10.0^approx_order
-    FD = LinearOperator{Float64}(1,2,1.0,N,:Neumann0,:Neumann0)
+    FD = DerivativeOperator{Float64}(1,2,1.0,N,:Neumann0,:Neumann0)
     first_deriv = FD*res
     @test first_deriv[1] ≈ 0.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0
     @test first_deriv[end] ≈ 0.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0
@@ -19,20 +19,20 @@ context("Neumann0 Boundary:")do
     d_order = 4
     approx_order = 10
     y = collect(1:1.0:N).^4 - 2*collect(1:1.0:N).^3 + collect(1:1.0:N).^2;
-    A = LinearOperator{Float64}(d_order,approx_order,1.0,N,:Neumann0,:Neumann0)
+    A = DerivativeOperator{Float64}(d_order,approx_order,1.0,N,:Neumann0,:Neumann0)
     boundary_points = A.boundary_point_count
     res = A*y
     @test res[boundary_points + 1: N - boundary_points] ≈ 24.0*ones(N - 2*boundary_points) atol=10.0^-1; # Float64 is less stable
-    FD = LinearOperator{Float64}(1,2,1.0,N,:Neumann0,:Neumann0)
+    FD = DerivativeOperator{Float64}(1,2,1.0,N,:Neumann0,:Neumann0)
     first_deriv = FD*res
     @test first_deriv[1] ≈ 0.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0
     @test first_deriv[end] ≈ 0.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0
 
-    A = LinearOperator{BigFloat}(d_order,approx_order,one(BigFloat),N,:Neumann0,:Neumann0)
+    A = DerivativeOperator{BigFloat}(d_order,approx_order,one(BigFloat),N,:Neumann0,:Neumann0)
     y = convert(Array{BigFloat, 1}, y)
     res = A*y
     @test res[boundary_points + 1: N - boundary_points] ≈ 24.0*ones(N - 2*boundary_points) atol=10.0^-approx_order;
-    FD = LinearOperator{BigFloat}(1,2,one(BigFloat),N,:Neumann0,:Neumann0)
+    FD = DerivativeOperator{BigFloat}(1,2,one(BigFloat),N,:Neumann0,:Neumann0)
     first_deriv = FD*res
     @test first_deriv[1] ≈ 0.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0
     @test first_deriv[end] ≈ 0.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0
@@ -44,11 +44,11 @@ context("General Neumann Boundary Condition:")do
     d_order = 2
     approx_order = 2
     x = 0:h_inv:π
-    A = LinearOperator{Float64}(2,2,h_inv,N,:Neumann,:Neumann;BC=(1,-1))
+    A = DerivativeOperator{Float64}(2,2,h_inv,N,:Neumann,:Neumann;BC=(1,-1))
     boundary_points = A.boundary_point_count
     res = A*sin.(x)
     @test res ≈ cos.(x) atol=10.0^approx_order
-    FD = LinearOperator{Float64}(1,2,h_inv,N,:None,:None)
+    FD = DerivativeOperator{Float64}(1,2,h_inv,N,:None,:None)
     first_deriv_res = FD*res
     @test first_deriv_res[1] ≈ -1.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0
     @test first_deriv_res[end] ≈ +1.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0
@@ -59,16 +59,16 @@ context("General Neumann Boundary Condition:")do
     d_order = 2
     approx_order = 2
     x = 0:h_inv:1
-    A = LinearOperator{Float64}(d_order,approx_order,h_inv,N,:Neumann,:Neumann;BC=(1,-1))
+    A = DerivativeOperator{Float64}(d_order,approx_order,h_inv,N,:Neumann,:Neumann;BC=(1,-1))
     boundary_points = A.boundary_point_count
     res = A*(x.*(1-x))
     @test res ≈ -2*ones(x) atol=10.0^-approx_order
 
-    # A = LinearOperator{BigFloat}(d_order,approx_order,N,:Neumann0,:Neumann0)
+    # A = DerivativeOperator{BigFloat}(d_order,approx_order,N,:Neumann0,:Neumann0)
     # y = convert(Array{BigFloat, 1}, y)
     # res = A*y
     # @test res[boundary_points + 1: N - boundary_points] ≈ 24.0*ones(N - 2*boundary_points) atol=10.0^-approx_order;
-    # FD = LinearOperator{BigFloat}(1,2,N,:Neumann0,:Neumann0)
+    # FD = DerivativeOperator{BigFloat}(1,2,N,:Neumann0,:Neumann0)
     # first_deriv = FD*res
     # @test first_deriv[1] ≈ 0.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0
     # @test first_deriv[end] ≈ 0.0 atol=10.0^-1 ## Derivative at edges in Neumann 0 is 0

--- a/test/none.jl
+++ b/test/none.jl
@@ -5,7 +5,7 @@ context("One-sided derivatives at boundaries:") do
     N = 10
     d_order = 1
     approx_order = 2
-    A = LinearOperator{Float64}(d_order,approx_order,1.0,N,:None,:None)
+    A = DerivativeOperator{Float64}(d_order,approx_order,1.0,N,:None,:None)
     Amat = full(A)
 
     @test Amat[1,1:3] ≈ [-1.5, 2.0, -0.5]
@@ -15,7 +15,7 @@ context("One-sided derivatives at boundaries:") do
     @test Amat[end,end-2:end] ≈ [0.5, -2.0, 1.5]
 
     d_order = 2
-    A = LinearOperator{Float64}(d_order,approx_order,1.0,N,:None,:None)
+    A = DerivativeOperator{Float64}(d_order,approx_order,1.0,N,:None,:None)
     Amat = full(A)
 
     @test Amat[1,1:4] ≈ [2.0, -5.0, 4.0, -1.0]
@@ -27,7 +27,7 @@ context("One-sided derivatives at boundaries:") do
     N = 10
     d_order = 1
     approx_order = 3
-    A = LinearOperator{Float64}(d_order,approx_order,1.0,N,:None,:None)
+    A = DerivativeOperator{Float64}(d_order,approx_order,1.0,N,:None,:None)
     Amat = full(A)
 
     @test Amat[1,1:4] ≈ [-11/6, 3, -3/2, 1/3]

--- a/test/periodic.jl
+++ b/test/periodic.jl
@@ -7,7 +7,7 @@ context("Periodic Boundary:")do
     d_order = 2
     approx_order = 2
     x = collect(1:1.0:N).^2
-    A = LinearOperator{Float64}(2,2,1.0,N,:periodic,:periodic)
+    A = DerivativeOperator{Float64}(2,2,1.0,N,:periodic,:periodic)
     boundary_points = A.boundary_point_count
 
     res = A*x
@@ -18,13 +18,13 @@ context("Periodic Boundary:")do
     approx_order = 10
     y = collect(1:1.0:N).^4 - 2*collect(1:1.0:N).^3 + collect(1:1.0:N).^2;
 
-    A = LinearOperator{Float64}(d_order,approx_order,1.0,N,:periodic,:periodic)
+    A = DerivativeOperator{Float64}(d_order,approx_order,1.0,N,:periodic,:periodic)
     boundary_points = A.boundary_point_count
 
     res = A*y
     @test res[boundary_points + 1: N - boundary_points] ≈ 24.0*ones(N - 2*boundary_points) atol=10.0^-1; # Float64 is less stable
 
-    A = LinearOperator{BigFloat}(d_order,approx_order,one(BigFloat),N,:periodic,:periodic)
+    A = DerivativeOperator{BigFloat}(d_order,approx_order,one(BigFloat),N,:periodic,:periodic)
     y = convert(Array{BigFloat, 1}, y)
     res = A*y;
     @test res[boundary_points + 1: N - boundary_points] ≈ 24.0*ones(N - 2*boundary_points) atol=10.0^-approx_order;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ context("Full and Sparse functions:")do
     approx_order = 2
     x = collect(1:1.0:N).^2
 
-    A = LinearOperator{Float64}(d_order,approx_order,1.0,N,:Dirichlet0,:Dirichlet0)
+    A = DerivativeOperator{Float64}(d_order,approx_order,1.0,N,:Dirichlet0,:Dirichlet0)
     mat = full(A)
     sp_mat = sparse(A)
     @test mat == sp_mat;
@@ -34,7 +34,7 @@ context("Full and Sparse functions:")do
     y = collect(1:1.0:N).^4 - 2*collect(1:1.0:N).^3 + collect(1:1.0:N).^2;
     y = convert(Array{BigFloat, 1}, y)
 
-    A = LinearOperator{BigFloat}(d_order,approx_order,one(BigFloat),N,:Dirichlet0,:Dirichlet0)
+    A = DerivativeOperator{BigFloat}(d_order,approx_order,one(BigFloat),N,:Dirichlet0,:Dirichlet0)
     boundary_points = A.boundary_point_count
     mat = full(A, N)
     sp_mat = sparse(A)
@@ -52,7 +52,7 @@ context("Indexing tests:")do
     d_order = 4
     approx_order = 10
 
-    A = LinearOperator{Float64}(d_order,approx_order,1.0,N,:Dirichlet0,:Dirichlet0)
+    A = DerivativeOperator{Float64}(d_order,approx_order,1.0,N,:Dirichlet0,:Dirichlet0)
     @test A[1,1] ≈ 13.717407 atol=1e-4
     @test A[:,1] == (full(A))[:,1]
     @test A[10,20] == 0
@@ -66,7 +66,7 @@ context("Indexing tests:")do
     d_order = 2
     approx_order = 2
 
-    A = LinearOperator{Float64}(d_order,approx_order,1.0,N,:Dirichlet0,:Dirichlet0)
+    A = DerivativeOperator{Float64}(d_order,approx_order,1.0,N,:Dirichlet0,:Dirichlet0)
     M = full(A)
 
     @test A[1,1] == -2.0
@@ -87,8 +87,8 @@ context("Operations on matrices:")do
     dy = yarr[2]-yarr[1]
     F = [x^2+y for x = xarr, y = yarr]
 
-    A = LinearOperator{Float64}(d_order,approx_order,dx,length(xarr),:None,:None)
-    B = LinearOperator{Float64}(d_order,approx_order,dy,length(yarr),:None,:None)
+    A = DerivativeOperator{Float64}(d_order,approx_order,dx,length(xarr),:None,:None)
+    B = DerivativeOperator{Float64}(d_order,approx_order,dy,length(yarr),:None,:None)
 
     @test A*F ≈ 2*ones(N,M) atol=1e-2
     @test F*B ≈ 8*ones(N,M) atol=1e-2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using PDEOperators
+using DiffEqOperators
 using Base.Test
 using FactCheck
 using SpecialMatrices


### PR DESCRIPTION
This moves the concrete operator types out of DiffEqBase to here, leaving only the interface specification there. Thus this includes DiffEqScalar and DiffEqArrayOperator. The previous operators all share a lot of code, so those are now in a folder. All of those operators now fall under the abstract type `AbstractDiffEqDerivativeOperator <: AbstractDiffEqLinearOperator` as they are linear operators which describe discretizations of derivatives.

This then does the rename to DiffEqOperators as PDEOperators may be a too "domain-special acronym" to get registered, while we have free reign to register things under DiffEq. It also covers the fact that more than PDEs can be specified by these operators anyways.