### PR TITLE
Operator norm

### DIFF
--- a/src/array_operator.jl
+++ b/src/array_operator.jl
@@ -63,6 +63,7 @@ function Base.expm(L::DiffEqArrayOperator)
 end
 DiffEqBase.has_expm(L::DiffEqArrayOperator) = true
 Base.size(L::DiffEqArrayOperator) = size(L.A)
+Base.norm(L::DiffEqArrayOperator, p::Real=2) = norm(L.A, p)
 DiffEqBase.update_coefficients!(L::DiffEqArrayOperator,t,u) = (L.update_func(L.A,t,u); L.α = L.α(t); nothing)
 DiffEqBase.update_coefficients(L::DiffEqArrayOperator,t,u)  = (L.update_func(L.A,t,u); L.α = L.α(t); L)
 

--- a/src/derivative_operators/derivative_operator.jl
+++ b/src/derivative_operators/derivative_operator.jl
@@ -601,6 +601,18 @@ Base.ctranspose(A::AbstractDerivativeOperator) = A
 Base.issymmetric(::AbstractDerivativeOperator) = true
 
 #=
+    The Inf norm can be calculated easily using the stencil coeffiicents, while other norms 
+    default to compute from the full matrix form.
+=#
+function Base.norm(A::DerivativeOperator{T,S,LBC,RBC}, p::Real=2) where {T,S,LBC,RBC}
+    if p == Inf && LBC in [:Dirichlet0, :Neumann0, :periodic] && RBC in [:Dirichlet0, :Neumann0, :periodic]
+        sum(abs.(A.stencil_coefs)) / A.dx^A.derivative_order
+    else
+        norm(full(A), p)
+    end
+end
+
+#=
     This function ideally should give us a matrix which when multiplied with the input vector
     returns the derivative. But the presence of different boundary conditons complicates the
     situation. It is not possible to incorporate the full information of the boundary conditions

--- a/src/derivative_operators/upwind_operator.jl
+++ b/src/derivative_operators/upwind_operator.jl
@@ -223,3 +223,15 @@ function right_nothing_BC!(::Type{Val{:UO}},high_boundary_coefs,down_stencil_len
     push!(high_boundary_coefs, negate!(calculate_weights(derivative_order, -(0)*grid_step, reverse(collect(zero(T) : -grid_step : -(boundary_length-1)*grid_step)))))
     return r_diff
 end
+
+#=
+    The Inf norm can be calculated easily using the stencil coeffiicents, while other norms 
+    default to compute from the full matrix form.
+=#
+function Base.norm(A::UpwindOperator{T,S,LBC,RBC}, p::Real=2) where {T,S,LBC,RBC}
+    if p == Inf && LBC in [:Dirichlet0, :Neumann0, :periodic] && RBC in [:Dirichlet0, :Neumann0, :periodic]
+        max(sum(abs.(A.up_stencil_coefs)) / A.dx^A.derivative_order, sum(abs.(A.down_stencil_coefs)) / A.dx^A.derivative_order)
+    else
+        norm(full(A), p)
+    end
+end

--- a/test/derivative_operators_interface.jl
+++ b/test/derivative_operators_interface.jl
@@ -12,6 +12,7 @@
     @test full(A, 10) == -Strang(10); # Strang Matrix is defined with the center term +ve
     @test full(A, N) == -Strang(N); # Strang Matrix is defined with the center term +ve
     @test full(A) == sp_mat
+    @test norm(A, Inf) == norm(mat, Inf)
 
     # testing correctness
     N = 1000


### PR DESCRIPTION
This is mostly to prepare for the exponential Krylov integrators using _Expokit.jl_, which require the operator's norm for error estimation.

For the derivative operators, the Inf norm can be calculated efficiently using the stencil coefficients (this is also what _Expokit_ requires). The other norms default to calling `Base.norm` on the full matrix.

 _Expokit_ accepts both `DerivativeOperator` and `UpwindOperator` now:

```julia
using DiffEqOperators
using Expokit: expmv
N = 1000
dx = 0.1
dt = 0.1
tol = 1e-5
u = rand(N)

L1 = DerivativeOperator{Float64}(2,4,dx,N,:Dirichlet0,:Dirichlet0)
A1 = full(L1)
@show isapprox(expm(A1*dt)*u, expmv(dt, L1, u); rtol=tol) # true

L2 = UpwindOperator{Float64}(2,4,dx,N,BitVector(N),:Dirichlet0,:Dirichlet0)
A2 = full(L2)
@show isapprox(expm(A2*dt)*u, expmv(dt, L2, u); rtol=tol) # true
```

Note that the calculated norm does not make sense for Dirichlet1 and Neumann1 BC currently because operators with these BC aren't even linear in the first place. This should not be a problem after the BC overhaul #53 is done because the interior section `u[iidxs]` does in fact form a vector space, unlike the full domain `u`.