### PR TITLE
Column stacking form in the overview

### DIFF
--- a/docs/linear_operators_overview.tex
+++ b/docs/linear_operators_overview.tex
@@ -46,20 +46,19 @@
 		Use $i=1,... I_j$ as the grid in the interior. Moreover, define $I_{j,L}$ and $I_{j,H}$ as the non interior grid points. Therefore, $\hat{I}_j = I_j + I_{j,L} + I_{j,H}$. % Again, I think you mean I_j's in above cases.
 		 Notice that the solution to the discretized function is $u \in R^{\hat{I}}$ if stationary.
 		
-		We construct the discretized $\hat{u}$ as a block matrix of size $\hat{I}\times n$:
+		We construct the discretized $\hat{u}$ by column stacking the discretized $\hat{u}_{x^j}$ on each grid $j \in \{1,...,n\}$:
 		\begin{equation}
 		\hat{u} = \begin{bmatrix}
-		\hat{u}_{x^1} & \mathbf{0}_1       & ...    & \mathbf{0}_1\\
-		\mathbf{0}_2       & \hat{u}_{x^2} & ...    & \mathbf{0}_2\\
-		\vdots  & \vdots  & \ddots & \vdots \\
-		\mathbf{0}_n       & \mathbf{0}_n       & ...    & \hat{u}_{x^n}\\
+		\hat{u}_{x^1}\\
+		\hat{u}_{x^2}\\
+		\vdots\\
+		\hat{u}_{x^n}\\
 		\end{bmatrix}\label{u_def}
 		\end{equation}
-		where, $\mathbf{0}_j$ is a block of zeros with size $\hat{I}_j \times 1$.
 		
 		
 		
-		\item For any arbitrary variable $y(x)$ defined in the whole space of $x$, we define $\hat{y}$ as its discretization on the whole domain of $x$ and $y$ as the discretization only for interior points of the domain. So while $\hat{y}$ has dimension $\hat{I} \times n$, $y$ has dimension $I \times n$.
+		\item For any arbitrary variable $y(x)$ defined in the whole space of $x$, we define $\hat{y}$ as its discretization on the whole domain of $x$ and $y$ as the discretization only for interior points of the domain. So while $\hat{y}$ has length $\hat{I}$, $y$ has length $I$.
 	\end{itemize}
 	
 	\section{General Overview of Discretization and Boundary Values}\label{sec:general}
@@ -86,13 +85,13 @@
 		\hat{u}
 		=
 		\begin{bmatrix}
-		\text{z}_{{1},L} & \mathbf{0}_{1,L}       & ...    & \mathbf{0}_{1,L}\\
-		\text{z}_{{1},H} & \mathbf{0}_{1,H}       & ...    & \mathbf{0}_{1,H}\\
-		\mathbf{0}_{2,L}   & \text{z}_{{2},L} &   ...    & \mathbf{0}_{2,L}\\
-		\mathbf{0}_{2,H}   & \text{z}_{{2},H} &   ...    & \mathbf{0}_{2,H}\\
-		\vdots  & \vdots  & \ddots & \vdots \\
-		\mathbf{0}_{N,L}       & ...    & \mathbf{0}_{N,L} & \text{z}_{{N},L} & \\
-		\mathbf{0}_{N,H}       & ...    & \mathbf{0}_{N,H} & \text{z}_{{N},H} & \\
+		\text{z}_{{1},L}\\
+		\text{z}_{{1},H}\\
+		\text{z}_{{2},L}\\
+		\text{z}_{{2},H}\\
+		\vdots\\
+		\text{z}_{{N},L}\\
+		\text{z}_{{N},H}\\
 		\end{bmatrix}
 		%\begin{bmatrix}
 		%\text{z}_{1, L}&\text{z}_{2, L}&\dots&\text{z}_{n, L}\\
@@ -172,13 +171,13 @@
 		\hat{u}
 		=
 		\begin{bmatrix}
-		\text{z}_{{1},L} & \mathbf{0}_{1,L}       & ...    & \mathbf{0}_{1,L}\\
-		\text{z}_{{1},H} & \mathbf{0}_{1,H}       & ...    & \mathbf{0}_{1,H}\\
-		\mathbf{0}_{2,L}   & \text{z}_{{2},L} &   ...    & \mathbf{0}_{2,L}\\
-		\mathbf{0}_{2,H}   & \text{z}_{{2},H} &   ...    & \mathbf{0}_{2,H}\\
-		\vdots  & \vdots  & \ddots & \vdots \\
-		\mathbf{0}_{N,L}       & ...    & \mathbf{0}_{N,L} & \text{z}_{{N},L} & \\
-		\mathbf{0}_{N,H}       & ...    & \mathbf{0}_{N,H} & \text{z}_{{N},H} & \\
+		\text{z}_{{1},L}\\
+		\text{z}_{{1},H}\\
+		\text{z}_{{2},L}\\
+		\text{z}_{{2},H}\\
+		\vdots\\
+		\text{z}_{{N},L}\\
+		\text{z}_{{N},H}\\
 		\end{bmatrix}
 		%\begin{bmatrix}
 		%\text{z}_{1, L}&\text{z}_{2, L}&\dots&\text{z}_{n, L}\\
@@ -202,7 +201,7 @@
 		\begin{align}
 		R(A-[A[:,1:I_L] A[:,\hat{I}-I_H+1:\hat{I}]]\cdot([B[:,1:I_L] B[:,\hat{I}-I_H+1:\hat{I}]]^{-1} B)) = A\cdot Q_a\label{affine_relation_2}
 		\end{align}		
-Our intuition is that the main idea here is using interiors to recover a relation that boundary conditions should satisfy. Since $Q_b$ is a $\hat{I}\times 1$ matrix containing zeros excepts two ends, the two non-zero elements in $Q_b$ capture partial information of boundary nodes (the part that is ``independent'' of interiors).  Recall \eqref{B_operator_block}, so $\left([B[:,1:I_L] B[:,\hat{I}-I_H+1:\hat{I}]]^{-1}\begin{bmatrix}
+Our intuition is that the main idea here is using interiors to recover a relation that boundary conditions should satisfy. Since $Q_b$ is a length $\hat{I}$ vector containing zeros excepts two ends, the two non-zero elements in $Q_b$ capture partial information of boundary nodes (the part that is ``independent'' of interiors).  Recall \eqref{B_operator_block}, so $\left([B[:,1:I_L] B[:,\hat{I}-I_H+1:\hat{I}]]^{-1}\begin{bmatrix}
 		\text{z}_{x^{1},L} & ... & \text{z}_{x^{N},L}\\
 		\text{z}_{x^{2},H} & ... & \text{z}_{x^{N},H}
 		\end{bmatrix}\right)$ recovers the ``independent" part of boundary nodes. Then it is reasonable to expect that \eqref{affine_relation_1} holds.


### PR DESCRIPTION
@jlperla We discussed this Monday about the form of the solution. I have changed the overview document to use the column stacking form. This shouldn't affect the operators in any way.

BTW, is the overview document intended as an internal sketch or is it meant to be presented to the users? If it's the latter case, I think it's better to restructure the document to first discuss the univariate case and then include a section for the multivariate generalization (which doesn't really add anything to our approach to the BC). This should make the discussions much easier to follow.