### PR TITLE
Add tutorial on creating a sparse matrix representation of 2D finite difference operators

### DIFF
--- a/docs/Poisson2D.md
+++ b/docs/Poisson2D.md
@@ -1,0 +1,30 @@
+# Solving the 2D Poisson equation using DiffEqOperators
+
+This tutorial demonstrates how to use `DiffEqOperators` to construct finite difference approximations of two-dimensional operators for the solution of elliptic partial differential equations. For simplicity, we consider the Poisson equation on the unit square with homogeneous Dirichlet conditions:
+
+    -Δu = -∂_xx u -∂_yy u = f on [0,1]²,
+                        u = 0 on ∂[0,1]².
+
+The following function uses a Kronecker product of one-dimensional differential operators to construct the two-dimensional finite difference approximation of the Laplace operator -Δ using N×N points as a sparse matrix:
+
+```julia
+using DiffEqOperators, SparseArrays, LinearAlgebra
+function Laplacian2D(N)
+    h = 1/N
+    D2 = sparse(DerivativeOperator{Float64}(2,2,h,N,:Dirichlet0,:Dirichlet0))
+    Id = sparse(I,N,N)
+    A = -kron(D2,Id) - kron(Id,D2)
+    return A
+end
+```
+
+This can be used to solve the Poisson equation for f ≡ 1 as follows:
+
+```julia
+N = 128
+A = Laplacian2D(N)
+f = fill(1.0,N*N)
+u = reshape(A\f,N,N)
+using GR; surface(u)
+```
+

--- a/docs/Poisson2D.md
+++ b/docs/Poisson2D.md
@@ -28,3 +28,15 @@ u = reshape(A\f,N,N)
 using GR; surface(u)
 ```
 
+This approach extends to higher dimensions as well; e.g., the Laplacian on the unit cube can be constructed by
+
+```julia
+function Laplacian§D(N)
+    h = 1/N
+    D2 = sparse(DerivativeOperator{Float64}(2,2,h,N,:Dirichlet0,:Dirichlet0))
+    Id = sparse(I,N,N)
+    A = -kron(D2,Id,Id) - kron(Id,D2,Id) - kron(Id,Id,D2)
+    return A
+end
+```
+


### PR DESCRIPTION
This pull request adds a brief tutorial based on the example from #73, which might be helpful for other people looking to use `DiffEqOperators` to construct finite difference approximations for simple two-dimensional operators. Tested on v0.7 and v1.0.

(The approach actually extends to 3+D very easily via, e.g., 
```julia 
A = -kron(D1,Id,Id) - kron(Id,D1,Id) - kron(Id,Id,D1)
```
but that's probably a not so common use case.)