### PR TITLE
WIP Overload array constructors

### DIFF
--- a/src/DiffEqOperators.jl
+++ b/src/DiffEqOperators.jl
@@ -4,7 +4,7 @@ import Base: +, -, *, /, \, size, getindex, setindex!, Matrix, convert
 using DiffEqBase, StaticArrays, LinearAlgebra
 import LinearAlgebra: mul!, ldiv!, lmul!, rmul!, axpy!, opnorm, factorize, I
 import DiffEqBase: AbstractDiffEqLinearOperator, update_coefficients!, is_constant
-using SparseArrays, ForwardDiff
+using SparseArrays, ForwardDiff, BandedMatrices
 
 abstract type AbstractDerivativeOperator{T} <: AbstractDiffEqLinearOperator{T} end
 abstract type AbstractDiffEqCompositeOperator{T} <: AbstractDiffEqLinearOperator{T} end

--- a/src/derivative_operators/derivative_irreg_operator.jl
+++ b/src/derivative_operators/derivative_irreg_operator.jl
@@ -408,17 +408,17 @@ function LinearAlgebra.Array(A::FiniteDifference{T}) where T
     extended_x = one(T).*[-A.dx[1]; zero(T); cumsum([A.dx; A.dx[N-1]])]
 
     # Apply lower stencils
-    for i in 1:stl_2-1
+    for i in 1:stl_2
         L[i,1:stl] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[1:stl])
     end
 
     # Apply inner stencils
-    for i in max(stl_2,1):N-stl_2+1
-        L[i,i-stl_2+1:i+stl_2+1] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[i+1-stl_2:i+1+stl_2])
+    for i in max(stl_2,1)+1:N-stl_2
+        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs[i-max(stl_2,1)]
     end
 
     # Apply upper stencils
-    for i in N-stl_2+2:N
+    for i in N-stl_2+1:N
         L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[N-stl+3:N+2])
     end
     return L
@@ -432,21 +432,22 @@ function SparseArrays.SparseMatrixCSC(A::FiniteDifference{T}) where T
     extended_x = one(T).*[-A.dx[1]; zero(T); cumsum([A.dx; A.dx[N-1]])]
 
     # Apply lower stencils
-    for i in 1:stl_2-1
+    for i in 1:stl_2
         L[i,1:stl] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[1:stl])
     end
 
     # Apply inner stencils
-    for i in max(stl_2,1):N-stl_2+1
-        L[i,i-stl_2+1:i+stl_2+1] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[i+1-stl_2:i+1+stl_2])
+    for i in max(stl_2,1)+1:N-stl_2
+        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs[i-max(stl_2,1)]
     end
 
     # Apply upper stencils
-    for i in N-stl_2+2:N
+    for i in N-stl_2+1:N
         L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[N-stl+3:N+2])
     end
     return L
 end
+
 
 function BandedMatrices.BandedMatrix(A::FiniteDifference{T}) where T
     N = A.dimension
@@ -456,17 +457,17 @@ function BandedMatrices.BandedMatrix(A::FiniteDifference{T}) where T
     extended_x = one(T).*[-A.dx[1]; zero(T); cumsum([A.dx; A.dx[N-1]])]
 
     # Apply lower stencils
-    for i in 1:stl_2-1
+    for i in 1:stl_2
         L[i,1:stl] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[1:stl])
     end
 
     # Apply inner stencils
-    for i in max(stl_2,1):N-stl_2+1
-        L[i,i-stl_2+1:i+stl_2+1] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[i+1-stl_2:i+1+stl_2])
+    for i in max(stl_2,1)+1:N-stl_2
+        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs[i-max(stl_2,1)]
     end
 
     # Apply upper stencils
-    for i in N-stl_2+2:N
+    for i in N-stl_2+1:N
         L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[N-stl+3:N+2])
     end
     return L

--- a/src/derivative_operators/derivative_irreg_operator.jl
+++ b/src/derivative_operators/derivative_irreg_operator.jl
@@ -402,48 +402,48 @@ end
 
 function LinearAlgebra.Array(A::FiniteDifference{T}) where T
     N = A.dimension
-    L = zeros(T, N, N+2)
-    stl = A.stencil_length
-    stl_2 = div(stl,2)
-    extended_x = one(T).*[-A.dx[1]; zero(T); cumsum([A.dx; A.dx[N-1]])]
+    L = zeros(T, N, N
+    stl_2 = div(A.stencil_length,2)
+    lbc, ubc = A.boundary_point_count
 
     # Apply lower stencils
-    for i in 1:stl_2
-        L[i,1:stl] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[1:stl])
+    for i in 1:lbc
+        L[i,1:A.boundary_length[1]] = A.low_boundary_coefs[][i]
     end
 
     # Apply inner stencils
-    for i in max(stl_2,1)+1:N-stl_2
-        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs[i-max(stl_2,1)]
+    for i in lbc+1:N-ubc
+        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs[i-lbc]
     end
 
     # Apply upper stencils
-    for i in N-stl_2+1:N
-        L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[N-stl+3:N+2])
+    for i in N-ubc+1:N
+        L[i,N-A.boundary_length[2]+3:N+2] = A.high_boundary_coefs[][i-N+ubc]
     end
-    return L
+    return L 
 end
+
+
 
 function SparseArrays.SparseMatrixCSC(A::FiniteDifference{T}) where T
     N = A.dimension
     L = spzeros(T, N, N+2)
-    stl = A.stencil_length
-    stl_2 = div(stl,2)
-    extended_x = one(T).*[-A.dx[1]; zero(T); cumsum([A.dx; A.dx[N-1]])]
+    stl_2 = div(A.stencil_length,2)
+    lbc, ubc = A.boundary_point_count
 
     # Apply lower stencils
-    for i in 1:stl_2
-        L[i,1:stl] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[1:stl])
+    for i in 1:lbc
+        L[i,1:A.boundary_length[1]] = A.low_boundary_coefs[][i]
     end
 
     # Apply inner stencils
-    for i in max(stl_2,1)+1:N-stl_2
-        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs[i-max(stl_2,1)]
+    for i in lbc+1:N-ubc
+        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs[i-lbc]
     end
 
     # Apply upper stencils
-    for i in N-stl_2+1:N
-        L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[N-stl+3:N+2])
+    for i in N-ubc+1:N
+        L[i,N-A.boundary_length[2]+3:N+2] = A.high_boundary_coefs[][i-N+ubc]
     end
     return L
 end
@@ -454,21 +454,21 @@ function BandedMatrices.BandedMatrix(A::FiniteDifference{T}) where T
     stl = A.stencil_length
     stl_2 = div(stl,2)
     L = BandedMatrix{T}(undef, (N, N+2), (max(stl-3,0),max(stl-1,0)))
-    extended_x = one(T).*[-A.dx[1]; zero(T); cumsum([A.dx; A.dx[N-1]])]
+    lbc, ubc = A.boundary_point_count
 
     # Apply lower stencils
-    for i in 1:stl_2
-        L[i,1:stl] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[1:stl])
+    for i in 1:lbc
+        L[i,1:A.boundary_length[1]] = A.low_boundary_coefs[][i]
     end
 
     # Apply inner stencils
-    for i in max(stl_2,1)+1:N-stl_2
-        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs[i-max(stl_2,1)]
+    for i in lbc+1:N-ubc
+        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs[i-lbc]
     end
 
     # Apply upper stencils
-    for i in N-stl_2+1:N
-        L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, extended_x[i+1], extended_x[N-stl+3:N+2])
+    for i in N-ubc+1:N
+        L[i,N-A.boundary_length[2]+3:N+2] = A.high_boundary_coefs[][i-N+ubc]
     end
     return L
 end

--- a/src/derivative_operators/derivative_irreg_operator.jl
+++ b/src/derivative_operators/derivative_irreg_operator.jl
@@ -453,7 +453,7 @@ function BandedMatrices.BandedMatrix(A::FiniteDifference{T}) where T
     N = A.dimension
     stl = A.stencil_length
     stl_2 = div(stl,2)
-    L = BandedMatrix{T}(undef, (N, N+2), (max(stl_2,1),stl))
+    L = BandedMatrix{T}(undef, (N, N+2), (max(stl-3,0),max(stl-1,0)))
     extended_x = one(T).*[-A.dx[1]; zero(T); cumsum([A.dx; A.dx[N-1]])]
 
     # Apply lower stencils

--- a/src/derivative_operators/derivative_operator.jl
+++ b/src/derivative_operators/derivative_operator.jl
@@ -456,22 +456,22 @@ end
 function LinearAlgebra.Array(A::DerivativeOperator{T}) where T
     N = A.dimension
     L = zeros(T, N, N+2)
-    stl = A.stencil_length
-    stl_2 = div(stl,2)
+    stl_2 = div(A.stencil_length,2)
+    lbc, ubc = A.boundary_point_count
 
     # Apply lower stencils
-    for i in 1:stl_2-1
-        L[i,1:stl] = calculate_weights(A.derivative_order, one(T)*(i), one(T) .* collect(0:1:stl-1))
+    for i in 1:lbc
+        L[i,1:A.boundary_length[1]] = A.low_boundary_coefs[][i]
     end
 
     # Apply inner stencils
-    for i in max(stl_2,1):N-stl_2+1
+    for i in lbc+1:N-ubc
         L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs
     end
 
     # Apply upper stencils
-    for i in N-stl_2+2:N
-        L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, one(T)*(i-N+stl-2), one(T) .* collect(0:1:stl-1))
+    for i in N-ubc+1:N
+        L[i,N-A.boundary_length[2]+3:N+2] = A.high_boundary_coefs[][i-N+ubc]
     end
     return L ./ A.dx^A.derivative_order
 end
@@ -479,22 +479,22 @@ end
 function SparseArrays.SparseMatrixCSC(A::DerivativeOperator{T}) where T
     N = A.dimension
     L = spzeros(T, N, N+2)
-    stl = A.stencil_length
-    stl_2 = div(stl,2)
+    stl_2 = div(A.stencil_length,2)
+    lbc, ubc = A.boundary_point_count
 
     # Apply lower stencils
-    for i in 1:stl_2-1
-        L[i,1:stl] = calculate_weights(A.derivative_order, one(T)*(i), one(T) .* collect(0:1:stl-1))
+    for i in 1:lbc
+        L[i,1:A.boundary_length[1]] = A.low_boundary_coefs[][i]
     end
 
     # Apply inner stencils
-    for i in max(stl_2,1):N-stl_2+1
+    for i in lbc+1:N-ubc
         L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs
     end
 
     # Apply upper stencils
-    for i in N-stl_2+2:N
-        L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, one(T)*(i-N+stl-2), one(T) .* collect(0:1:stl-1))
+    for i in N-ubc+1:N
+        L[i,N-A.boundary_length[2]+3:N+2] = A.high_boundary_coefs[][i-N+ubc]
     end
     return L ./ A.dx^A.derivative_order
 end
@@ -504,20 +504,21 @@ function BandedMatrices.BandedMatrix(A::DerivativeOperator{T}) where T
     stl = A.stencil_length
     stl_2 = div(stl,2)
     L = BandedMatrix{T}(undef, (N, N+2), (max(stl-3,0),max(stl-1,0)))
+    lbc, ubc = A.boundary_point_count
 
     # Apply lower stencils
-    for i in 1:stl_2-1
-        L[i,1:stl] = calculate_weights(A.derivative_order, one(T)*(i), one(T) .* collect(0:1:stl-1))
+    for i in 1:lbc
+        L[i,1:A.boundary_length[1]] = A.low_boundary_coefs[][i]
     end
 
     # Apply inner stencils
-    for i in max(stl_2,1):N-stl_2+1
+    for i in lbc+1:N-ubc
         L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs
     end
 
     # Apply upper stencils
-    for i in N-stl_2+2:N
-        L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, one(T)*(i-N+stl-2), one(T) .* collect(0:1:stl-1))
+    for i in N-ubc+1:N
+        L[i,N-A.boundary_length[2]+3:N+2] = A.high_boundary_coefs[][i-N+ubc]
     end
     return L ./ A.dx^A.derivative_order
 end

--- a/src/derivative_operators/derivative_operator.jl
+++ b/src/derivative_operators/derivative_operator.jl
@@ -452,3 +452,72 @@ function LinearAlgebra.opnorm(A::DerivativeOperator{T,S,LBC,RBC}, p::Real=2) whe
         opnorm(convert(Array,A), p)
     end
 end
+
+function LinearAlgebra.Array(A::DerivativeOperator{T}) where T
+    N = A.dimension
+    L = zeros(T, N, N+2)
+    stl = A.stencil_length
+    stl_2 = div(stl,2)
+
+    # Apply lower stencils
+    for i in 1:stl_2-1
+        L[i,1:stl] = calculate_weights(A.derivative_order, one(T)*(i), one(T) .* collect(0:1:stl-1))
+    end
+
+    # Apply inner stencils
+    for i in max(stl_2,1):N-stl_2+1
+        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs
+    end
+
+    # Apply upper stencils
+    for i in N-stl_2+2:N
+        L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, one(T)*(i-N+stl-2), one(T) .* collect(0:1:stl-1))
+    end
+    return L ./ A.dx^A.derivative_order
+end
+
+function SparseArrays.SparseMatrixCSC(A::DerivativeOperator{T}) where T
+    N = A.dimension
+    L = spzeros(T, N, N+2)
+    stl = A.stencil_length
+    stl_2 = div(stl,2)
+
+    # Apply lower stencils
+    for i in 1:stl_2-1
+        L[i,1:stl] = calculate_weights(A.derivative_order, one(T)*(i), one(T) .* collect(0:1:stl-1))
+    end
+
+    # Apply inner stencils
+    for i in max(stl_2,1):N-stl_2+1
+        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs
+    end
+
+    # Apply upper stencils
+    for i in N-stl_2+2:N
+        L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, one(T)*(i-N+stl-2), one(T) .* collect(0:1:stl-1))
+    end
+    return L ./ A.dx^A.derivative_order
+end
+
+function BandedMatrices.BandedMatrix(A::DerivativeOperator{T}) where T
+    N = A.dimension
+    stl = A.stencil_length
+    stl_2 = div(stl,2)
+    L = BandedMatrix{T}(undef, (N, N+2), (max(stl_2,1),stl))
+
+    # Apply lower stencils
+    for i in 1:stl_2-1
+        L[i,1:stl] = calculate_weights(A.derivative_order, one(T)*(i), one(T) .* collect(0:1:stl-1))
+    end
+
+    # Apply inner stencils
+    for i in max(stl_2,1):N-stl_2+1
+        L[i,i-stl_2+1:i+stl_2+1] = A.stencil_coefs
+    end
+
+    # Apply upper stencils
+    for i in N-stl_2+2:N
+        L[i,N-stl+3:N+2] = calculate_weights(A.derivative_order, one(T)*(i-N+stl-2), one(T) .* collect(0:1:stl-1))
+    end
+    return L ./ A.dx^A.derivative_order
+end

--- a/src/derivative_operators/derivative_operator.jl
+++ b/src/derivative_operators/derivative_operator.jl
@@ -503,7 +503,7 @@ function BandedMatrices.BandedMatrix(A::DerivativeOperator{T}) where T
     N = A.dimension
     stl = A.stencil_length
     stl_2 = div(stl,2)
-    L = BandedMatrix{T}(undef, (N, N+2), (max(stl_2,1),stl))
+    L = BandedMatrix{T}(undef, (N, N+2), (max(stl-3,0),max(stl-1,0)))
 
     # Apply lower stencils
     for i in 1:stl_2-1


### PR DESCRIPTION
A second pass of the implementation of array constructor overloads, for the types DerivativeOperator and FiniteDifference (the central difference implementations). Resolves handling of stencils near boundaries.