### PR TITLE
fix boundary stencil

### DIFF
--- a/src/derivative_operators/derivative_operator.jl
+++ b/src/derivative_operators/derivative_operator.jl
@@ -17,7 +17,7 @@ struct DerivativeOperator{T<:Real,S<:SVector} <: AbstractDerivativeOperator{T}
         dx                   = dx
         stencil_length       = derivative_order + approximation_order - 1 + (derivative_order+approximation_order)%2
         dummy_x              = -div(stencil_length,2) : div(stencil_length,2)
-        deriv_spots          = -div(stencil_length,2) : -1
+        deriv_spots          = (-div(stencil_length,2)+1) : -1
         boundary_length      = length(deriv_spots)
 
         stencil_coefs        = convert(SVector{stencil_length, T}, calculate_weights(derivative_order, zero(T), dummy_x))


### PR DESCRIPTION
Shivin noticed that the issue is that the 0 point shouldn't ever be on the end, just 1 off. This should fix the boundary stencils.