### PR TITLE
Add `opnorm` to jacvec operators

### DIFF
--- a/src/matrixfree_operators.jl
+++ b/src/matrixfree_operators.jl
@@ -6,7 +6,7 @@ mutable struct MatrixFreeOperator{F,N,S,O} <: AbstractMatrixFreeOperator{F}
   opnorm::O
   ishermitian::Bool
   function MatrixFreeOperator(f::F, args::N;
-                              size=nothing, opnorm=nothing, ishermitian=false) where {F,N}
+                              size=nothing, opnorm=true, ishermitian=false) where {F,N}
     @assert (N <: Tuple && length(args) in (1,2)) "Arguments of a "*
     "MatrixFreeOperator must be a tuple with one or two elements"
     return new{F,N,typeof(size),typeof(opnorm)}(f, args, size, opnorm, ishermitian)

--- a/test/jacvec_operators.jl
+++ b/test/jacvec_operators.jl
@@ -52,12 +52,12 @@ function lorenz(du,u,p,t)
 end
 u0 = [1.0;0.0;0.0]
 tspan = (0.0,100.0)
-ff = ODEFunction(lorenz,jac_prototype=JacVecOperator{Float64}(lorenz,u0))
-prob = ODEProblem(ff,u0,tspan)
-@test_broken sol = solve(prob,Rosenbrock23())
-@test_broken sol = solve(prob,Rosenbrock23(linsolve=LinSolveGMRES(tol=1e-10)))
-
-ff = ODEFunction(lorenz,jac_prototype=JacVecOperator{Float64}(lorenz,u0,autodiff=false))
-prob = ODEProblem(ff,u0,tspan)
-@test_broken sol = solve(prob,Rosenbrock23())
-@test_broken sol = solve(prob,Rosenbrock23(linsolve=LinSolveGMRES(tol=1e-10)))
+ff1 = ODEFunction(lorenz,jac_prototype=JacVecOperator{Float64}(lorenz,u0))
+ff2 = ODEFunction(lorenz,jac_prototype=JacVecOperator{Float64}(lorenz,u0,autodiff=false))
+for ff in [ff1, ff2]
+  prob = ODEProblem(ff,u0,tspan)
+  @test solve(prob,TRBDF2()).retcode == :Success
+  @test solve(prob,TRBDF2(linsolve=LinSolveGMRES(tol=1e-10))).retcode == :Success
+  @test_broken sol = solve(prob,Rosenbrock23())
+  @test_broken sol = solve(prob,Rosenbrock23(linsolve=LinSolveGMRES(tol=1e-10)))
+end

--- a/test/jacvec_operators.jl
+++ b/test/jacvec_operators.jl
@@ -58,6 +58,7 @@ for ff in [ff1, ff2]
   prob = ODEProblem(ff,u0,tspan)
   @test solve(prob,TRBDF2()).retcode == :Success
   @test solve(prob,TRBDF2(linsolve=LinSolveGMRES(tol=1e-10))).retcode == :Success
+  @test solve(prob,Exprb32()).retcode == :Success
   @test_broken sol = solve(prob,Rosenbrock23())
   @test_broken sol = solve(prob,Rosenbrock23(linsolve=LinSolveGMRES(tol=1e-10)))
 end


### PR DESCRIPTION
This PR enables `JacVecOperator` to work with `Exprb` solvers.