### PR TITLE
Fix kernel flipping in NNlib.conv call

### DIFF
--- a/src/derivative_operators/derivative_operator_functions.jl
+++ b/src/derivative_operators/derivative_operator_functions.jl
@@ -59,7 +59,7 @@ for MT in [2,3]
             setindex!(Widx,:,N)
             W[Widx...] = s
 
-            cv = DenseConvDims(_M, W, padding=pad)
+            cv = DenseConvDims(_M, W, padding=pad,flipkernel=true)
             conv!(_x_temp, _M, W, cv)
 
             # Now deal with boundaries

--- a/test/differentiation_dimension.jl
+++ b/test/differentiation_dimension.jl
@@ -204,3 +204,98 @@ end
     # Test that * agrees will mul!
     @test M_temp == L*M
 end
+
+@testset "Differentiating with non-symmetric interior stencil" begin
+
+    # The following tests check that multiplication of an operator with a
+    # non-symmetric interior stencil is consistent with what we expect
+
+    N = 1
+    L = CenteredDifference{N}(3,4,0.1,30)
+    M = zeros(32,32)
+    for i in 1:32
+        for j in 1:32
+            M[i,j] = cos(0.1i)
+        end
+    end
+
+    M_temp = zeros(30,32)
+    mul!(M_temp, L, M)
+
+    @test M_temp ≈ Array(L)*M
+
+    N = 2
+    L = CenteredDifference{N}(3,4,0.1,30)
+    M = zeros(32,32)
+    for i in 1:32
+        for j in 1:32
+            M[i,j] = cos(0.1j)
+        end
+    end
+
+    M_temp = zeros(32,30)
+    mul!(M_temp, L, M)
+
+    @test M_temp ≈ transpose(Array(L)*transpose(M))
+
+    # Three dimensions
+
+    N = 1
+    L = CenteredDifference{N}(3,4,0.1,30)
+    M = zeros(32,32,32)
+    for i in 1:32
+        for j in 1:32
+            for k in 1:32
+                M[i,j,k] = cos(0.1i)
+            end
+        end
+    end
+
+    M_temp = zeros(30,32,32)
+    mul!(M_temp, L, M)
+    for i in 1:32
+        @test M_temp[:,:,i] ≈ Array(L)*M[:,:,i]
+    end
+
+    correct_row = L*M[:,1,1]
+
+    N = 2
+    L = CenteredDifference{N}(3,4,0.1,30)
+    M = zeros(32,32,32)
+    for i in 1:32
+        for j in 1:32
+            for k in 1:32
+                M[i,j,k] = cos(0.1j)
+            end
+        end
+    end
+
+    M_temp = zeros(32,30,32)
+    mul!(M_temp, L, M)
+
+    for i in 1:32
+        for j in 1:32
+            @test M_temp[i,:,j] ≈ correct_row
+        end
+    end
+
+    N = 3
+    L = CenteredDifference{N}(3,4,0.1,30)
+    M = zeros(32,32,32)
+    for i in 1:32
+        for j in 1:32
+            for k in 1:32
+                M[i,j,k] = cos(0.1k)
+            end
+        end
+    end
+
+    M_temp = zeros(32,32,30)
+    mul!(M_temp, L, M)
+
+    for i in 1:32
+        for j in 1:32
+            @test M_temp[i,j,:] ≈ correct_row
+        end
+    end
+end


### PR DESCRIPTION
@ChrisRackauckas  this should be good to merge. The only change is that we are now flipping the kernel correctly before calling NNlib.conv!. Also, a few tests for non-symmetric stencils were added, which were missing earlier and hence we didn't see this issue earlier. 

